### PR TITLE
Add Configuration and ApiVersion classes for SDK setup

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk;
+
+use Apiera\WooPhpSdk\Enum\ApiVersion;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+final readonly class Configuration
+{
+    public function __construct(
+        private string $baseUrl,
+        private string $consumerKey,
+        private string $consumerSecret,
+        private ApiVersion $apiVersion,
+        private string $userAgent,
+        private int $timeout,
+    ) {
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    public function getConsumerKey(): string
+    {
+        return $this->consumerKey;
+    }
+
+    public function getConsumerSecret(): string
+    {
+        return $this->consumerSecret;
+    }
+
+    public function getApiVersion(): ApiVersion
+    {
+        return $this->apiVersion;
+    }
+
+    public function getUserAgent(): string
+    {
+        return $this->userAgent;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+}

--- a/src/Enum/ApiVersion.php
+++ b/src/Enum/ApiVersion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Enum;
+
+enum ApiVersion: string
+{
+    case V1 = 'wp-json/wc/v1';
+    case V2 = 'wp-json/wc/v2';
+    case V3 = 'wp-json/wc/v3';
+}


### PR DESCRIPTION
Introduces the `Configuration` class to handle SDK setup and configuration parameters like base URL, credentials, and API version. Defines the `ApiVersion` enum to standardize supported WooCommerce API versions. These additions lay the groundwork for the SDK's core functionality.