### PR TITLE
Add HTTP exception handling and related classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         }
     ],
     "require": {
-        "php": "^8.3"
+        "php": "^8.3",
+        "psr/http-message": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc4a5038f4d2cb579fe01e9a87c2c58a",
-    "packages": [],
+    "content-hash": "30fedd4d852441fbac0273e199e314dc",
+    "packages": [
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "apiera/php-standards",

--- a/src/DTO/HttpErrorMessage.php
+++ b/src/DTO/HttpErrorMessage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\DTO;
+
+final readonly class HttpErrorMessage
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        private string $code,
+        private string $message,
+        private array $data,
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Enum/ApiVersion.php
+++ b/src/Enum/ApiVersion.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Apiera\WooPhpSdk\Enum;
 
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
 enum ApiVersion: string
 {
     case V1 = 'wp-json/wc/v1';

--- a/src/Exception/Http/BadRequestException.php
+++ b/src/Exception/Http/BadRequestException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Exception\Http;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+final class BadRequestException extends HttpException
+{
+}

--- a/src/Exception/Http/HttpException.php
+++ b/src/Exception/Http/HttpException.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Exception\Http;
+
+use Apiera\WooPhpSdk\DTO\HttpErrorMessage;
+use Exception;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Base exception for all HTTP/API related errors
+ *
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+abstract class HttpException extends Exception
+{
+    /** @var array<string, mixed>|null */
+    private ?array $responseData = null;
+
+    /** @var array<string, mixed>|null */
+    private ?array $requestData = null;
+
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly ?ResponseInterface $response = null,
+        string $message = '',
+    ) {
+        parent::__construct($message);
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getRequestMethod(): string
+    {
+        return $this->request->getMethod();
+    }
+
+    public function getRequestUri(): string
+    {
+        return (string) $this->request->getUri();
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getRequestHeaders(): array
+    {
+        return $this->request->getHeaders();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getRequestData(): ?array
+    {
+        if ($this->requestData !== null) {
+            return $this->requestData;
+        }
+
+        $body = (string) $this->request->getBody();
+
+        if (strlen($body) === 0) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        $this->requestData = $data;
+
+        return $data;
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function hasResponse(): bool
+    {
+        return $this->response !== null;
+    }
+
+    public function getResponseStatusCode(): ?int
+    {
+        return $this->response?->getStatusCode();
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getResponseHeaders(): array
+    {
+        return $this->response?->getHeaders() ?? [];
+    }
+
+    public function getErrorMessage(): HttpErrorMessage
+    {
+        if ($this->response === null) {
+            return new HttpErrorMessage(
+                'unknown_error',
+                $this->getMessage() !== '' ? $this->getMessage() : 'An unknown error occurred',
+                ['status' => 0]
+            );
+        }
+
+        $data = $this->getResponseData();
+
+        if ($data === null || !isset($data['code'], $data['message'])) {
+            return new HttpErrorMessage(
+                'invalid_response',
+                'Invalid response received from the API',
+                ['status' => $this->response->getStatusCode()]
+            );
+        }
+
+        return new HttpErrorMessage(
+            $data['code'],
+            $data['message'],
+            $data['data'] ?? ['status' => $this->response->getStatusCode()]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function getResponseData(): ?array
+    {
+        if ($this->responseData !== null) {
+            return $this->responseData;
+        }
+
+        if ($this->response === null) {
+            return null;
+        }
+
+        $body = (string) $this->response->getBody();
+        $data = json_decode($body, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        $this->responseData = $data;
+
+        return $data;
+    }
+}

--- a/src/Exception/Http/InternalServerErrorException.php
+++ b/src/Exception/Http/InternalServerErrorException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Exception\Http;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+final class InternalServerErrorException extends HttpException
+{
+}

--- a/src/Exception/Http/NotFoundException.php
+++ b/src/Exception/Http/NotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Exception\Http;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+final class NotFoundException extends HttpException
+{
+}

--- a/src/Exception/Http/UnauthorizedException.php
+++ b/src/Exception/Http/UnauthorizedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\WooPhpSdk\Exception\Http;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.1.0
+ */
+final class UnauthorizedException extends HttpException
+{
+}

--- a/tests/Unit/Exception/Http/HttpExceptionTest.php
+++ b/tests/Unit/Exception/Http/HttpExceptionTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception\Http;
+
+use Apiera\WooPhpSdk\Exception\Http\BadRequestException;
+use Apiera\WooPhpSdk\Exception\Http\HttpException;
+use Apiera\WooPhpSdk\Exception\Http\InternalServerErrorException;
+use Apiera\WooPhpSdk\Exception\Http\NotFoundException;
+use Apiera\WooPhpSdk\Exception\Http\UnauthorizedException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+#[CoversClass(HttpException::class)]
+#[CoversClass(BadRequestException::class)]
+#[CoversClass(InternalServerErrorException::class)]
+#[CoversClass(NotFoundException::class)]
+#[CoversClass(UnauthorizedException::class)]
+final class HttpExceptionTest extends TestCase
+{
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testExceptionWithoutResponse(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getMethod')->willReturn('GET');
+        $request->method('getUri')->willReturn($this->createConfiguredMock(UriInterface::class, [
+            '__toString' => 'https://example.com/api',
+        ]));
+        $request->method('getHeaders')->willReturn(['Content-Type' => ['application/json']]);
+
+        $exception = new BadRequestException($request, null, 'Test message');
+
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertNull($exception->getResponse());
+        $this->assertFalse($exception->hasResponse());
+        $this->assertNull($exception->getResponseStatusCode());
+        $this->assertSame([], $exception->getResponseHeaders());
+        $this->assertSame('GET', $exception->getRequestMethod());
+        $this->assertSame('https://example.com/api', $exception->getRequestUri());
+        $this->assertSame(['Content-Type' => ['application/json']], $exception->getRequestHeaders());
+
+        $errorMessage = $exception->getErrorMessage();
+        $this->assertSame('unknown_error', $errorMessage->getCode());
+        $this->assertSame('Test message', $errorMessage->getMessage());
+        $this->assertSame(['status' => 0], $errorMessage->getData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testExceptionWithValidResponse(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        $responseBody = json_encode([
+            'code' => 'not_found',
+            'message' => 'Resource not found',
+            'data' => ['status' => 404],
+        ]);
+
+        $stream->method('__toString')->willReturn($responseBody);
+        $response->method('getBody')->willReturn($stream);
+        $response->method('getStatusCode')->willReturn(404);
+        $response->method('getHeaders')->willReturn(['Content-Type' => ['application/json']]);
+
+        $exception = new NotFoundException($request, $response);
+
+        $this->assertTrue($exception->hasResponse());
+        $this->assertSame(404, $exception->getResponseStatusCode());
+        $this->assertSame(['Content-Type' => ['application/json']], $exception->getResponseHeaders());
+
+        $errorMessage = $exception->getErrorMessage();
+        $this->assertSame('not_found', $errorMessage->getCode());
+        $this->assertSame('Resource not found', $errorMessage->getMessage());
+        $this->assertSame(['status' => 404], $errorMessage->getData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testExceptionWithInvalidResponseBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        $stream->method('__toString')->willReturn('invalid json');
+        $response->method('getBody')->willReturn($stream);
+        $response->method('getStatusCode')->willReturn(500);
+
+        $exception = new InternalServerErrorException($request, $response);
+
+        $errorMessage = $exception->getErrorMessage();
+        $this->assertSame('invalid_response', $errorMessage->getCode());
+        $this->assertSame('Invalid response received from the API', $errorMessage->getMessage());
+        $this->assertSame(['status' => 500], $errorMessage->getData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testExceptionWithIncompleteResponseData(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        // Response missing required fields
+        $responseBody = json_encode(['some' => 'data']);
+
+        $stream->method('__toString')->willReturn($responseBody);
+        $response->method('getBody')->willReturn($stream);
+        $response->method('getStatusCode')->willReturn(400);
+
+        $exception = new BadRequestException($request, $response);
+
+        $errorMessage = $exception->getErrorMessage();
+        $this->assertSame('invalid_response', $errorMessage->getCode());
+        $this->assertSame('Invalid response received from the API', $errorMessage->getMessage());
+        $this->assertSame(['status' => 400], $errorMessage->getData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testRequestDataHandling(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        $requestBody = json_encode(['test' => 'data']);
+        $stream->method('__toString')->willReturn($requestBody);
+        $request->method('getBody')->willReturn($stream);
+
+        $exception = new UnauthorizedException($request);
+
+        $this->assertSame(['test' => 'data'], $exception->getRequestData());
+        // Test caching
+        $this->assertSame(['test' => 'data'], $exception->getRequestData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testEmptyRequestBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        $stream->method('__toString')->willReturn('');
+        $request->method('getBody')->willReturn($stream);
+
+        $exception = new UnauthorizedException($request);
+
+        $this->assertNull($exception->getRequestData());
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testInvalidRequestBodyJson(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+
+        $stream->method('__toString')->willReturn('invalid json');
+        $request->method('getBody')->willReturn($stream);
+
+        $exception = new UnauthorizedException($request);
+
+        $this->assertNull($exception->getRequestData());
+    }
+}


### PR DESCRIPTION
Introduced `HttpException` as a base class for handling HTTP-related errors, alongside specific exceptions like `BadRequestException`, `NotFoundException`, `UnauthorizedException`, and `InternalServerErrorException`. Created supporting DTO `HttpErrorMessage` for structured error messaging and added unit tests to ensure robustness. Updated `composer.json` to include `psr/http-message` dependency.